### PR TITLE
feat: Make accountId optional in GetContactInput GraphQL schema

### DIFF
--- a/terraform/contact_query.graphql
+++ b/terraform/contact_query.graphql
@@ -43,7 +43,7 @@ input UpdateContactInput {
 }
 
 input GetContactInput {
-  accountId: String!
+  accountId: String
   email: String!
 }
 

--- a/test-payloads/test_get_contact_email_only.json
+++ b/test-payloads/test_get_contact_email_only.json
@@ -1,0 +1,8 @@
+{
+  "query": "query GetContact($input: GetContactInput!) { getContact(input: $input) { contactId accountId email firstName lastName } }",
+  "variables": {
+    "input": {
+      "email": "authorized@example.com"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Made `accountId` field optional in `GetContactInput` GraphQL schema
- Aligned GraphQL API with Lambda function capabilities for email-only contact lookups
- Added test payload for email-only contact queries

## Changes Made
- **Modified**: `terraform/contact_query.graphql` - Changed `accountId: String!` → `accountId: String`
- **Added**: `test-payloads/test_get_contact_email_only.json` - Test payload for new functionality

## Technical Details
The contact Lambda function was updated to support email-only lookups (making `accountId` optional), but the GraphQL schema still required both fields. This PR updates the schema to match the Lambda capabilities.

## Testing
✅ **Terraform validated and deployed successfully**
✅ **Live API testing completed on bff.steverhoton.com**
- Traditional query (accountId + email): Working ✓
- New email-only query: Working ✓
- Both return identical contact data

## Test plan
- [x] Terraform fmt, validate, and apply completed
- [x] GraphQL schema updated and deployed
- [x] API tested with both query patterns
- [x] Backwards compatibility verified
- [x] New functionality verified

🤖 Generated with [Claude Code](https://claude.ai/code)