### PR TITLE
fix: Add locationId field to GraphQL location types

### DIFF
--- a/terraform/location_query.graphql
+++ b/terraform/location_query.graphql
@@ -1,0 +1,137 @@
+# Location union type for polymorphic location handling
+union Location = AddressLocation | CoordinatesLocation
+
+# Address location type definition
+type AddressLocation {
+  locationId: String!
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  address: Address!
+}
+
+# Coordinates location type definition  
+type CoordinatesLocation {
+  locationId: String!
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  coordinates: Coordinates!
+}
+
+# Address type definition
+type Address {
+  streetAddress: String!
+  streetAddress2: String
+  city: String!
+  stateProvince: String
+  postalCode: String!
+  country: String!
+}
+
+# Coordinates type definition
+type Coordinates {
+  latitude: Float!
+  longitude: Float!
+  altitude: Float
+  accuracy: Float
+}
+
+# List output type for paginated location results
+type LocationListOutput {
+  locations: [Location!]!
+  nextCursor: String
+}
+
+# Input types for location operations
+input CreateLocationInput {
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  address: AddressInput
+  coordinates: CoordinatesInput
+}
+
+input CreateAddressLocationInput {
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  address: AddressInput!
+}
+
+input CreateCoordinatesLocationInput {
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  coordinates: CoordinatesInput!
+}
+
+input UpdateLocationInput {
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  address: AddressInput
+  coordinates: CoordinatesInput
+}
+
+input UpdateAddressLocationInput {
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  address: AddressInput!
+}
+
+input UpdateCoordinatesLocationInput {
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  coordinates: CoordinatesInput!
+}
+
+input AddressInput {
+  streetAddress: String!
+  streetAddress2: String
+  city: String!
+  stateProvince: String
+  postalCode: String!
+  country: String!
+}
+
+input CoordinatesInput {
+  latitude: Float!
+  longitude: Float!
+  altitude: Float
+  accuracy: Float
+}
+
+input GetLocationInput {
+  accountId: String!
+  locationId: String!
+}
+
+input DeleteLocationInput {
+  accountId: String!
+  locationId: String!
+}
+
+input ListLocationsInput {
+  accountId: String!
+  limit: Int
+  cursor: String
+}
+
+input UpdateLocationByIdInput {
+  locationId: String!
+  input: UpdateLocationInput!
+}
+
+input UpdateAddressLocationByIdInput {
+  locationId: String!
+  input: UpdateAddressLocationInput!
+}
+
+input UpdateCoordinatesLocationByIdInput {
+  locationId: String!
+  input: UpdateCoordinatesLocationInput!
+}
+

--- a/test-payloads/get_location.json
+++ b/test-payloads/get_location.json
@@ -1,0 +1,9 @@
+{
+  "query": "query GetLocation($input: GetLocationInput!) { getLocation(input: $input) { ... on AddressLocation { locationId accountId locationType extendedAttributes address { streetAddress city stateProvince postalCode country } } ... on CoordinatesLocation { locationId accountId locationType extendedAttributes coordinates { latitude longitude altitude accuracy } } } }",
+  "variables": {
+    "input": {
+      "accountId": "e4c8f468-e0b1-7049-6f0f-48b0b4f27aa5",
+      "locationId": "82212e91-674f-4078-800e-1609314e4bf0"
+    }
+  }
+}

--- a/test-payloads/list_locations.json
+++ b/test-payloads/list_locations.json
@@ -1,0 +1,9 @@
+{
+  "query": "query ListLocations($input: ListLocationsInput!) { listLocations(input: $input) { locations { ... on AddressLocation { locationId accountId locationType extendedAttributes address { streetAddress city stateProvince postalCode country } } ... on CoordinatesLocation { locationId accountId locationType extendedAttributes coordinates { latitude longitude altitude accuracy } } } nextCursor } }",
+  "variables": {
+    "input": {
+      "accountId": "e4c8f468-e0b1-7049-6f0f-48b0b4f27aa5",
+      "limit": 10
+    }
+  }
+}


### PR DESCRIPTION
## Summary
• Fixed missing locationId field in GraphQL schema for location types
• Updated test payloads to include locationId in queries
• Resolves upstream team's reported issue with location ID handling

## Changes Made
• Added `locationId: String!` field to `AddressLocation` type
• Added `locationId: String!` field to `CoordinatesLocation` type  
• Updated `test-payloads/get_location.json` to request locationId
• Updated `test-payloads/list_locations.json` to request locationId

## Test Plan
- [x] Verify GraphQL schema compiles with new locationId fields
- [x] Test payloads updated to request locationId in query fragments
- [ ] Backend location service update to populate actual UUID locationIds
- [ ] Remove temporary hash-based ID workaround from frontend

🤖 Generated with [Claude Code](https://claude.ai/code)