### PR TITLE
feat: Add contactType field to Contact GraphQL schema

### DIFF
--- a/terraform/contact_query.graphql
+++ b/terraform/contact_query.graphql
@@ -7,6 +7,7 @@ type Contact {
   lastName: String
   phone: String
   status: String
+  contactType: String!
   locationIds: [String]
   config: AWSJSON
   createdAt: AWSDateTime!
@@ -23,6 +24,7 @@ type ContactListOutput {
 input CreateContactInput {
   accountId: String!
   email: String!
+  contactType: String!
   firstName: String
   lastName: String
   phone: String
@@ -34,6 +36,7 @@ input CreateContactInput {
 input UpdateContactInput {
   accountId: String!
   email: String!
+  contactType: String
   firstName: String
   lastName: String
   phone: String


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Added required `contactType` field to the Contact GraphQL type
- Made `contactType` required in `CreateContactInput` 
- Made `contactType` optional in `UpdateContactInput`

## Details
This change aligns the AppSync GraphQL schema with the contact resolver Lambda implementation that now requires and validates the `contactType` field. 

Valid values for `contactType` are:
- `employee` - Internal company employees
- `customer` - External customers  
- `vendor` - External vendors/suppliers

The validation is case-insensitive as implemented in the Lambda function.

## Test plan
- [x] Tested querying existing contacts (returns empty string for contactType)
- [x] Tested creating new contact with valid contactType ("customer")
- [x] Tested updating contact's contactType from "customer" to "employee"
- [x] Tested validation with invalid contactType (properly rejects with error)

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)