### PR TITLE
feat: Add GraphQL shop location support to BFF API

### DIFF
--- a/terraform/contact_query.graphql
+++ b/terraform/contact_query.graphql
@@ -74,8 +74,10 @@ type Mutation {
   deleteContact(input: DeleteContactInput!): Boolean
   createAddressLocation(input: CreateAddressLocationInput!): String
   createCoordinatesLocation(input: CreateCoordinatesLocationInput!): String
+  createShopLocation(input: CreateShopLocationInput!): String
   updateAddressLocation(locationId: String!, input: UpdateAddressLocationInput!): Boolean
   updateCoordinatesLocation(locationId: String!, input: UpdateCoordinatesLocationInput!): Boolean
+  updateShopLocation(locationId: String!, input: UpdateShopLocationInput!): Boolean
   deleteLocation(accountId: String!, locationId: String!): Boolean
   createAccount(input: CreateAccountInput!): Account
   updateAccount(input: UpdateAccountInput!): Account

--- a/terraform/location_query.graphql
+++ b/terraform/location_query.graphql
@@ -1,5 +1,5 @@
 # Location union type for polymorphic location handling
-union Location = AddressLocation | CoordinatesLocation
+union Location = AddressLocation | CoordinatesLocation | ShopLocation
 
 # Address location type definition
 type AddressLocation {
@@ -19,6 +19,15 @@ type CoordinatesLocation {
   coordinates: Coordinates!
 }
 
+# Shop location type definition
+type ShopLocation {
+  locationId: String!
+  accountId: String!
+  locationType: String!
+  extendedAttributes: AWSJSON
+  shop: Shop!
+}
+
 # Address type definition
 type Address {
   streetAddress: String!
@@ -35,6 +44,13 @@ type Coordinates {
   longitude: Float!
   altitude: Float
   accuracy: Float
+}
+
+# Shop type definition
+type Shop {
+  name: String!
+  contactId: String!
+  address: Address!
 }
 
 # List output type for paginated location results
@@ -57,6 +73,12 @@ input CreateCoordinatesLocationInput {
   extendedAttributes: AWSJSON
 }
 
+input CreateShopLocationInput {
+  accountId: String!
+  shop: ShopInput!
+  extendedAttributes: AWSJSON
+}
+
 
 input UpdateAddressLocationInput {
   accountId: String!
@@ -67,6 +89,12 @@ input UpdateAddressLocationInput {
 input UpdateCoordinatesLocationInput {
   accountId: String!
   coordinates: CoordinatesInput!
+  extendedAttributes: AWSJSON
+}
+
+input UpdateShopLocationInput {
+  accountId: String!
+  shop: ShopInput!
   extendedAttributes: AWSJSON
 }
 
@@ -84,6 +112,12 @@ input CoordinatesInput {
   longitude: Float!
   altitude: Float
   accuracy: Float
+}
+
+input ShopInput {
+  name: String!
+  contactId: String!
+  address: AddressInput!
 }
 
 # Removed GetLocationInput - now uses direct arguments

--- a/terraform/location_query.tf
+++ b/terraform/location_query.tf
@@ -108,6 +108,51 @@ EOF
 }
 EOF
 
+  # Request template for create shop location mutation (uses generic createLocation)
+  location_create_shop_request_template = <<EOF
+{
+  "version": "2017-02-28",
+  "operation": "Invoke",
+  "payload": {
+    "field": "createLocation",
+    "arguments": {
+      "input": {
+        "accountId": $util.toJson($context.arguments.input.accountId),
+        "locationType": "shop",
+        "shop": $util.toJson($context.arguments.input.shop),
+        "extendedAttributes": $util.toJson($context.arguments.input.extendedAttributes)
+      }
+    },
+    "identity": $util.toJson($context.identity),
+    "request": $util.toJson($context.request),
+    "source": $util.toJson($context.source)
+  }
+}
+EOF
+
+  # Request template for update shop location mutation (uses generic updateLocation)
+  location_update_shop_request_template = <<EOF
+{
+  "version": "2017-02-28",
+  "operation": "Invoke",
+  "payload": {
+    "field": "updateLocation",
+    "arguments": {
+      "locationId": $util.toJson($context.arguments.locationId),
+      "input": {
+        "accountId": $util.toJson($context.arguments.input.accountId),
+        "locationType": "shop",
+        "shop": $util.toJson($context.arguments.input.shop),
+        "extendedAttributes": $util.toJson($context.arguments.input.extendedAttributes)
+      }
+    },
+    "identity": $util.toJson($context.identity),
+    "request": $util.toJson($context.request),
+    "source": $util.toJson($context.source)
+  }
+}
+EOF
+
   # Request template for delete mutations (direct arguments)
   location_delete_request_template = <<EOF
 {
@@ -262,6 +307,32 @@ resource "aws_appsync_resolver" "update_coordinates_location" {
   type        = "Mutation"
 
   request_template  = local.location_update_coordinates_request_template
+  response_template = local.location_response_template
+
+  depends_on = [aws_appsync_graphql_api.bff_api]
+}
+
+# AppSync Resolver for createShopLocation mutation (uses generic createLocation)
+resource "aws_appsync_resolver" "create_shop_location" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  data_source = aws_appsync_datasource.location_lambda.name
+  field       = "createShopLocation"
+  type        = "Mutation"
+
+  request_template  = local.location_create_shop_request_template
+  response_template = local.location_response_template
+
+  depends_on = [aws_appsync_graphql_api.bff_api]
+}
+
+# AppSync Resolver for updateShopLocation mutation
+resource "aws_appsync_resolver" "update_shop_location" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  data_source = aws_appsync_datasource.location_lambda.name
+  field       = "updateShopLocation"
+  type        = "Mutation"
+
+  request_template  = local.location_update_shop_request_template
   response_template = local.location_response_template
 
   depends_on = [aws_appsync_graphql_api.bff_api]


### PR DESCRIPTION
## Summary

Adds support for shop location type to the GraphQL BFF API, integrating with the recently updated location lambda that now supports shop locations.

### Changes Made

- **GraphQL Schema Updates**:
  - Added `ShopLocation` type to the `Location` union
  - Added `Shop` type with `name`, `contactId`, and `address` fields
  - Added `createShopLocation` and `updateShopLocation` mutations
  - Added corresponding input types (`CreateShopLocationInput`, `UpdateShopLocationInput`, `ShopInput`)

- **Infrastructure Changes**:
  - Added AppSync resolvers for shop location mutations
  - Added request templates that map GraphQL shop operations to generic lambda operations
  - Configured proper field mapping to work with existing lambda handler

- **Integration**:
  - Shop mutations use generic `createLocation` and `updateLocation` lambda fields
  - Proper `locationType: "shop"` parameter mapping
  - Full CRUD support for shop locations

### Testing

- ✅ **Direct Lambda Testing**: Shop location creation returns UUID, retrieval includes proper `__typename`
- ✅ **GraphQL Schema Deployment**: Shop types and mutations available in deployed API
- ✅ **AppSync Integration**: All resolvers and templates properly configured
- ✅ **Terraform Deployment**: All infrastructure changes applied successfully

### Dependencies

This change builds on the shop location model support added to the location lambda. The lambda handler was updated to properly recognize shop location fields and return correct GraphQL type information.

🤖 Generated with [Claude Code](https://claude.ai/code)