### PR TITLE
feat: Add work orders GraphQL resolver with AppSync integration

### DIFF
--- a/terraform/authenticated_query.graphql
+++ b/terraform/authenticated_query.graphql
@@ -34,4 +34,6 @@ type Query {
   listLaborLines(input: ListLaborLinesInput!): [LaborLine!]!
   getTask(input: GetTaskInput!): Task
   listTasks(input: ListTasksInput!): TaskListResponse!
+  getWorkOrder(accountId: ID!, workOrderId: ID!): WorkOrder
+  listWorkOrders(accountId: ID!, includeDeleted: Boolean = false): [WorkOrder!]!
 }

--- a/terraform/contact_query.graphql
+++ b/terraform/contact_query.graphql
@@ -100,4 +100,7 @@ type Mutation {
   createTask(input: CreateTaskInput!): Task!
   updateTask(input: UpdateTaskInput!): Task!
   deleteTask(input: DeleteTaskInput!): DeleteTaskResponse!
+  createWorkOrder(input: CreateWorkOrderInput!): WorkOrder!
+  updateWorkOrder(input: UpdateWorkOrderInput!): WorkOrder!
+  deleteWorkOrder(accountId: ID!, workOrderId: ID!): Boolean!
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,7 +19,8 @@ locals {
     file("${path.module}/actions_query.graphql"),
     file("${path.module}/events_query.graphql"),
     file("${path.module}/labor_lines_query.graphql"),
-    file("${path.module}/tasks_query.graphql")
+    file("${path.module}/tasks_query.graphql"),
+    file("${path.module}/work_orders_query.graphql")
   ])
 }
 

--- a/terraform/work_orders_query.graphql
+++ b/terraform/work_orders_query.graphql
@@ -1,0 +1,38 @@
+# Work Orders GraphQL Schema
+# This schema defines work order types and operations for the AppSync API
+
+# Work Order Status enum with proper GraphQL naming
+enum WorkOrderStatus {
+  draft
+  pending
+  inProgress
+  done
+}
+
+# Input types for work order operations
+input CreateWorkOrderInput {
+  accountId: ID!
+  contactId: ID!
+  status: WorkOrderStatus!
+  notes: [String!]
+}
+
+input UpdateWorkOrderInput {
+  accountId: ID!
+  workOrderId: ID!
+  contactId: ID
+  status: WorkOrderStatus
+  notes: [String!]
+}
+
+# Main work order type
+type WorkOrder {
+  workOrderId: ID!
+  accountId: ID!
+  contactId: ID!
+  status: WorkOrderStatus!
+  notes: [String!]!
+  createdAt: AWSTimestamp!
+  updatedAt: AWSTimestamp!
+  deletedAt: AWSTimestamp
+}

--- a/terraform/work_orders_query.tf
+++ b/terraform/work_orders_query.tf
@@ -1,0 +1,163 @@
+# Local values for work orders query resolver
+locals {
+  # Lambda function name for work orders resolver
+  work_orders_lambda_function_name = "work-order-dev-lambda"
+
+  # Request template for work orders resolver with status mapping
+  work_orders_request_template = <<EOF
+## Transform arguments to map GraphQL enum values to lambda expectations
+#set($arguments = $context.arguments)
+#if($arguments.input && $arguments.input.status && $arguments.input.status == "inProgress")
+  #set($arguments.input.status = "in-progress")
+#end
+
+{
+  "version": "2017-02-28",
+  "operation": "Invoke",
+  "payload": {
+    "info": {
+      "fieldName": $util.toJson($context.info.fieldName)
+    },
+    "arguments": $util.toJson($arguments),
+    "identity": $util.toJson($context.identity),
+    "request": $util.toJson($context.request)
+  }
+}
+EOF
+
+  # Response template for work orders resolver with status mapping
+  work_orders_response_template = <<EOF
+## Transform lambda response to map status values back to GraphQL enum values
+#set($result = $context.result)
+#if($result && $util.isArray($result))
+  ## Handle array of work orders (listWorkOrders)
+  #foreach($workOrder in $result)
+    ## Always ensure status field exists and is valid
+    #set($validStatus = "draft")
+    #if($workOrder.status)
+      #set($statusStr = $workOrder.status.toString().toLowerCase().trim())
+      #if($statusStr.contains("progress"))
+        #set($validStatus = "inProgress")
+      #elseif($statusStr == "pending")
+        #set($validStatus = "pending")
+      #elseif($statusStr == "done")
+        #set($validStatus = "done")
+      #elseif($statusStr == "draft")
+        #set($validStatus = "draft")
+      #end
+    #end
+    #set($workOrder.status = $validStatus)
+  #end
+#elseif($result && $result.status)
+  ## Handle single work order
+  #set($validStatus = "draft")
+  #if($result.status)
+    #set($statusStr = $result.status.toString().toLowerCase().trim())
+    #if($statusStr.contains("progress"))
+      #set($validStatus = "inProgress")
+    #elseif($statusStr == "pending")
+      #set($validStatus = "pending")
+    #elseif($statusStr == "done")
+      #set($validStatus = "done")
+    #elseif($statusStr == "draft")
+      #set($validStatus = "draft")
+    #end
+  #end
+  #set($result.status = $validStatus)
+#end
+
+$util.toJson($result)
+EOF
+}
+
+# Data source for existing work orders lambda function
+data "aws_lambda_function" "work_orders_resolver" {
+  function_name = local.work_orders_lambda_function_name
+}
+
+# IAM policy for AppSync to invoke work orders lambda
+resource "aws_iam_role_policy" "appsync_work_orders_lambda_policy" {
+  name = "steverhoton-bff-appsync-work-orders-lambda-policy"
+  role = aws_iam_role.appsync_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction"
+        ]
+        Resource = data.aws_lambda_function.work_orders_resolver.arn
+      }
+    ]
+  })
+}
+
+# AppSync data source for work orders lambda
+resource "aws_appsync_datasource" "work_orders_lambda" {
+  api_id           = aws_appsync_graphql_api.bff_api.id
+  name             = "work_orders_lambda"
+  service_role_arn = aws_iam_role.appsync_lambda_role.arn
+  type             = "AWS_LAMBDA"
+
+  lambda_config {
+    function_arn = data.aws_lambda_function.work_orders_resolver.arn
+  }
+
+  depends_on = [aws_iam_role_policy.appsync_work_orders_lambda_policy]
+}
+
+# AppSync resolvers for work orders operations
+
+# Query resolvers
+resource "aws_appsync_resolver" "get_work_order" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  field       = "getWorkOrder"
+  type        = "Query"
+  data_source = aws_appsync_datasource.work_orders_lambda.name
+
+  request_template  = local.work_orders_request_template
+  response_template = local.work_orders_response_template
+}
+
+resource "aws_appsync_resolver" "list_work_orders" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  field       = "listWorkOrders"
+  type        = "Query"
+  data_source = aws_appsync_datasource.work_orders_lambda.name
+
+  request_template  = local.work_orders_request_template
+  response_template = local.work_orders_response_template
+}
+
+# Mutation resolvers
+resource "aws_appsync_resolver" "create_work_order" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  field       = "createWorkOrder"
+  type        = "Mutation"
+  data_source = aws_appsync_datasource.work_orders_lambda.name
+
+  request_template  = local.work_orders_request_template
+  response_template = local.work_orders_response_template
+}
+
+resource "aws_appsync_resolver" "update_work_order" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  field       = "updateWorkOrder"
+  type        = "Mutation"
+  data_source = aws_appsync_datasource.work_orders_lambda.name
+
+  request_template  = local.work_orders_request_template
+  response_template = local.work_orders_response_template
+}
+
+resource "aws_appsync_resolver" "delete_work_order" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  field       = "deleteWorkOrder"
+  type        = "Mutation"
+  data_source = aws_appsync_datasource.work_orders_lambda.name
+
+  request_template  = local.work_orders_request_template
+  response_template = local.work_orders_response_template
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive work orders GraphQL resolver functionality to the AppSync BFF API, completing the integration with the existing `work-order-dev-lambda` function.

### ✅ Key Features Implemented

- **Full CRUD Operations**: Create, read, update, delete, and list work orders
- **GraphQL Schema**: Complete type definitions with proper enum handling
- **Status Mapping**: VTL templates to handle GraphQL `inProgress` ↔ Lambda `in-progress` transformation
- **Authentication**: Integrated with existing Cognito authentication
- **Error Handling**: Robust status transformation with fallbacks for legacy data

### 📋 Changes Made

- **`work_orders_query.graphql`**: New schema with WorkOrderStatus enum and input/output types
- **`work_orders_query.tf`**: Terraform configuration for AppSync resolvers and Lambda integration
- **`authenticated_query.graphql`**: Added getWorkOrder and listWorkOrders queries
- **`contact_query.graphql`**: Added createWorkOrder, updateWorkOrder, and deleteWorkOrder mutations
- **`main.tf`**: Updated schema compilation to include work orders

### 🔧 Technical Implementation

- **VTL Templates**: Handle bidirectional status mapping between GraphQL enums and Lambda expectations
- **IAM Policies**: Proper permissions for AppSync to invoke work orders Lambda
- **Data Sources**: AppSync Lambda data source configuration
- **Error Handling**: Comprehensive status validation and default fallbacks

### ✅ Verification Results

All operations tested and verified with AWS credentials:
- ✅ Work order creation
- ✅ Work order retrieval  
- ✅ Work order updates (including status transitions)
- ✅ Work order deletion (soft delete)
- ✅ Authentication integration
- ✅ Status enum mapping (inProgress ↔ in-progress)

### 📊 Test Coverage

- Created test work orders via GraphQL
- Verified status transformations work correctly
- Tested authentication flows
- Confirmed soft delete functionality
- Validated all CRUD operations end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)