### PR TITLE
feat: Add listEventsByWorkOrder query support

### DIFF
--- a/terraform/authenticated_query.graphql
+++ b/terraform/authenticated_query.graphql
@@ -30,6 +30,7 @@ type Query {
   listEventsByUnit(input: ListEventsByUnitInput!): EventListOutput
   listEventsByCategory(input: ListEventsByCategoryInput!): EventListOutput
   listEventsByStatus(input: ListEventsByStatusInput!): EventListOutput
+  listEventsByWorkOrder(input: ListEventsByWorkOrderInput!): EventListOutput
   getLaborLine(input: GetLaborLineInput!): LaborLine
   listLaborLines(input: ListLaborLinesInput!): [LaborLine!]!
   getTask(input: GetTaskInput!): Task

--- a/terraform/events_query.graphql
+++ b/terraform/events_query.graphql
@@ -336,5 +336,13 @@ input ListEventsByStatusInput {
   nextToken: String
 }
 
+# List events by work order input
+input ListEventsByWorkOrderInput {
+  accountId: String!
+  workOrderId: String!
+  limit: Int
+  nextToken: String
+}
+
 # Event operations are defined in the main Query and Mutation types
 # in authenticated_query.graphql and contact_query.graphql respectively

--- a/terraform/events_query.tf
+++ b/terraform/events_query.tf
@@ -171,3 +171,16 @@ resource "aws_appsync_resolver" "delete_event" {
 
   depends_on = [aws_appsync_graphql_api.bff_api]
 }
+
+# AppSync Resolver for listEventsByWorkOrder query
+resource "aws_appsync_resolver" "list_events_by_work_order" {
+  api_id      = aws_appsync_graphql_api.bff_api.id
+  data_source = aws_appsync_datasource.events_lambda.name
+  field       = "listEventsByWorkOrder"
+  type        = "Query"
+
+  request_template  = local.events_request_template
+  response_template = local.events_response_template
+
+  depends_on = [aws_appsync_graphql_api.bff_api]
+}


### PR DESCRIPTION
## Summary
- Add listEventsByWorkOrder query to GraphQL schema for filtering events by work order
- Add ListEventsByWorkOrderInput type with accountId and workOrderId fields
- Add AppSync resolver for the new query endpoint

## Test plan
- [ ] Verify GraphQL schema compiles without errors
- [ ] Test the new query endpoint with sample data
- [ ] Validate resolver configuration and data source mapping

🤖 Generated with [Claude Code](https://claude.ai/code)